### PR TITLE
Include additional parameters as variables

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,9 +21,14 @@ RUN pip install -r requirements.txt
 
 # copy over entrypoint script
 COPY entrypoint.sh ./
+RUN chmod +x entrypoint.sh
+
+# copy run farmer script
+COPY run-farmer.sh ./
+RUN chmod +x run-farmer.sh
 
 #
 ENTRYPOINT ["/app/entrypoint.sh"]
 
 #
-CMD ["python3", "ms_rewards_farmer.py", "--no-images", "--dont-check-for-updates", "--fast", "--skip-unusual", "--no-webdriver-manager", "--on-finish", "exit"]
+CMD ["/app/run-farmer.sh"]

--- a/run-farmer.sh
+++ b/run-farmer.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+if [ -n "${DISCORD_WH+x}" ]; then
+  DISCORD="--discord ${DISCORD_WH}"
+fi
+
+if [ -n "${CURRENCY_VALUE+x}" ]; then
+  CURRENCY="--currency ${CURRENCY_VALUE}"
+fi
+
+python3 ms_rewards_farmer.py --dont-check-for-updates --skip-unusual --fast --no-images --no-webdriver-manager --on-finish exit $DISCORD $CURRENCY


### PR DESCRIPTION
New run-farmer.sh script for launching the bot. It includes capturing two docker environment variables to be passed to the bot:

`- DISCORD_WH=<URL>`

> --discord WEBHOOK_URL Use this argument to send logs to your Discord server through a webhook.

`- CURRENCY_VALUE=<VALUE>`

> --currency CURRENCY Converts your points into your preferred currency. Available currencies: EUR, USD, AUD, INR, GBP, CAD, JPY, CHF, NZD, ZAR, BRL, CNY, HKD, SGD, THB